### PR TITLE
Trim autocomplete suggestions for multiple completions

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,8 @@ class CommandPrompt extends InputPrompt {
           console.log()
           process.stdout.cursorTo(0)
           console.log(chalk.red('>> ') + chalk.grey('Available commands:'))
-          console.log(CommandPrompt.formatList(ac.matches))
+          console.log(CommandPrompt.formatList(
+              ac.matches.map(function (value) { return value.split(" ").slice(-1).join(); })))
           rewrite(line)
         }
       } catch (err) {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "devDependencies": {
     "chai": "^3.4.1",
-    "eslint": "^1.10.3",
-    "mocha": "^2.3.4",
-    "sinon": "^3.2.1"
+    "eslint": "^4.19.1",
+    "mocha": "^5.1.1",
+    "sinon": "^5.0.7"
   }
 }


### PR DESCRIPTION
I am leveraging your library for some ridiculous chains of autocompletions for commands, their options and autocomplete items assigned to those options. In the current state however the autocompletion is really noisy as it repeats the entire command thus far with all possible options:

<img width="1151" alt="screen shot 2018-05-12 at 01 20 32" src="https://user-images.githubusercontent.com/32624319/39950645-f102478a-5582-11e8-93e0-60f34bc71905.png">

In my PR I added a minor change wherein only the display output would be trimmed in order to have sane outputs like this:

<img width="583" alt="screen shot 2018-05-12 at 00 55 19" src="https://user-images.githubusercontent.com/32624319/39950668-14e0e1f2-5583-11e8-8c18-1376b7db8ccc.png">

I'd like you to check whether this change breaks anything on your end and would appreciate if you find this feature useful and merge as well as publish it to npm.