### PR TITLE
Add support for autocomplete on multi-word commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,16 @@ class CommandPrompt extends InputPrompt {
           ac = autoCompleters[context](line)
         }
         if (ac.match) {
-          rewrite(ac.match)
+          if (ac.match === line) {
+            rewrite(ac.match)
+          } else {
+            const lineItems = line.split(' ')
+            lineItems.pop()
+            rewrite([
+              ...lineItems,
+              ac.match
+            ].join(' '))
+          }
         } else if (ac.matches) {
           console.log()
           process.stdout.cursorTo(0)
@@ -215,8 +224,9 @@ class CommandPrompt extends InputPrompt {
       cmds = cmds.slice(1)
     }
 
+    const lastWord = line.split(' ').pop()
     cmds = cmds.reduce((sum, el) => {
-      RegExp(`^${line}`).test(el) && sum.push(el) && (max = Math.max(max, el.length))
+      RegExp(`^${lastWord}`).test(el) && sum.push(el) && (max = Math.max(max, el.length))
       return sum
     }, [])
 


### PR DESCRIPTION
Autocomplete previously worked on the whole line instead of singular
words. The preceeding words in a line would therefore be removed if the
user tried to autocomplete on the second (or later) word in the command.

Given a command with multiple words autocomplete now completes each word
rather than the whole line.