### PR TITLE
Sanitize regexp

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,8 @@ class CommandPrompt extends InputPrompt {
     }
 
     cmds = cmds.reduce((sum, el) => {
-      RegExp(`^${line}`).test(el) && sum.push(el) && (max = Math.max(max, el.length))
+      let sanitizedLine = line.replace(/[\\\.\+\*\?\^\$\[\]\(\)\{\}\/\'\#\:\!\=\|]/ig, "\\$&")
+      RegExp(`^${sanitizedLine}`).test(el) && sum.push(el) && (max = Math.max(max, el.length))
       return sum
     }, [])
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-command-prompt",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/*.js' 'test/*.js'",


### PR DESCRIPTION
If the autocomplete has to return something like `command\` it produces an error because that is put in the expression in a wrong way. This PR sanitize the string to create the RegEx.