### PR TITLE
Expose rl

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ let context
 
 let globalConfig
 const ELLIPSIS = '…'
+let rl
 
 class CommandPrompt extends InputPrompt {
 
@@ -339,6 +340,10 @@ class CommandPrompt extends InputPrompt {
     }
   }
 
+  static getRl() {
+    return rl
+  }
+
   static getHistory(context) {
     if (!context) {
       context = '_default'
@@ -353,6 +358,7 @@ class CommandPrompt extends InputPrompt {
   }
 
   render(error) {
+    rl = this.rl
     let bottomContent = ''
     let appendContent = ''
     let message = this.getQuestion()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-command-prompt",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/*.js' 'test/*.js'",


### PR DESCRIPTION
Sometimes, you want to interact with the readline instance used in the prompt. Now, you can get it calling the static method `getRl()`.

BTW, most of the new features added here are required by [Secrez](https://github.com/secrez/secrez), which has been the engine that have pushed a lot of improvements in the prompt in the last six months.