### PR TITLE
Adding onBeforeRewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ It is a function that will be executed if the user presses Ctrl-c.
 
 Sometimes, you need to do something when a key is pressed. Whatever you put in this function will be executed before the standard onKeyPress function.
 
+##### onBeforeRewrite
+
+Sometimes, after an autocomplete, you must perform some change on the line to be rewritten. This function allow you to do that.
+
 ##### saved history
 
 To save the history and start back from there, you can config a file for history.

--- a/index.js
+++ b/index.js
@@ -102,6 +102,11 @@ class CommandPrompt extends InputPrompt {
     }
 
     const rewrite = line => {
+      console.log(chalk.green(line))
+      if (this.opt.onBeforeRewrite) {
+        line = this.opt.onBeforeRewrite(line)
+        console.log(chalk.green(line))
+      }
       this.rl.line = line
       this.rl.write(null, {ctrl: true, name: 'e'})
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inquirer-command-prompt",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "license": "MIT",
   "scripts": {
     "lint": "eslint -c .eslintrc 'src/*.js' 'test/*.js'",


### PR DESCRIPTION
This allow to add to the option an onBeforeRewrite function.
The function accept the line as parameter and return a modified line. For example, let's say that you get the result of a search with some number and you want to type
```
cat #3
```
and, after pressing `tab`, you want to see something like
```
cat /dir/myfile.txt
```
You can pass to the options something like:
```
   ...,
   onBeforeRewrite: line => {
    if (/ #\d+(\w+:|)\/[\w\/]+/.test(line)) {
      line = line.replace(/ #\d+((\w+:|)\/[\w\/]+)/," $1")
    }
    return line
  }
```
BTW, this function is used precisely for that reason in [Secrez](https://github.com/secrez/secrez)